### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The `IDKit` library provides a simple Swift interface for prompting users for Wo
 ## Usage
 
 ```swift
-import IDKit;
+import IDKit
 
 let session = try await Session(AppID("app_ce4cb73cb75fc3b73b71ffb4de178410"), action: "test-action")
 
@@ -21,14 +21,14 @@ let connect_url = session.connect_url
 
 for try await status in session.status() {
 	switch status {
-		case .waitingForConnection:
-			print("Waiting for the user to scan the QR Code")
-		case .awaitingConfirmation:
-			print("Awaiting user confirmation")
-		case let .confirmed(proof):
-			print("Got proof: \(proof)")
-		case let .failed(error):
-			print("Got error: \(error.localizedDescription)")
+	case .waitingForConnection:
+		print("Waiting for the user to scan the QR Code")
+	case .awaitingConfirmation:
+		print("Awaiting user confirmation")
+	case let .confirmed(proof):
+		print("Got proof: \(proof)")
+	case let .failed(error):
+		print("Got error: \(error.localizedDescription)")
 	}
 }
 ```


### PR DESCRIPTION
Removed semi-colon from example code as modern Swift doesn't use them.