### PR TITLE
[ID-519] idkit-swift no longer compiles

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -3,46 +3,19 @@
     {
       "identity" : "bigint",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/attaswift/BigInt",
+      "location" : "https://github.com/attaswift/BigInt.git",
       "state" : {
-        "revision" : "793a7fac0bfc318e85994bf6900652e827aef33e",
-        "version" : "5.4.1"
+        "revision" : "99c4b9fb0f52dc9182aee106b07c3d205583b98c",
+        "version" : "5.6.0"
       }
     },
     {
-      "identity" : "generic-json-swift",
+      "identity" : "swift-asn1",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/iwill/generic-json-swift",
+      "location" : "https://github.com/apple/swift-asn1.git",
       "state" : {
-        "revision" : "0a06575f4038b504e78ac330913d920f1630f510",
-        "version" : "2.0.2"
-      }
-    },
-    {
-      "identity" : "secp256k1.swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/GigaBitcoin/secp256k1.swift.git",
-      "state" : {
-        "revision" : "9683e8e311c76d8114cd308b697dad2f9fc58fed",
-        "version" : "0.17.0"
-      }
-    },
-    {
-      "identity" : "swift-atomics",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-atomics.git",
-      "state" : {
-        "revision" : "cd142fd2f64be2100422d658e7411e39489da985",
-        "version" : "1.2.0"
-      }
-    },
-    {
-      "identity" : "swift-collections",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-collections.git",
-      "state" : {
-        "revision" : "3d2dc41a01f9e49d84f0a3925fb858bed64f702d",
-        "version" : "1.1.2"
+        "revision" : "a54383ada6cecde007d374f58f864e29370ba5c3",
+        "version" : "1.3.2"
       }
     },
     {
@@ -50,98 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "46072478ca365fe48370993833cb22de9b41567f",
-        "version" : "3.5.2"
-      }
-    },
-    {
-      "identity" : "swift-http-types",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-http-types",
-      "state" : {
-        "revision" : "1ddbea1ee34354a6a2532c60f98501c35ae8edfa",
-        "version" : "1.2.0"
-      }
-    },
-    {
-      "identity" : "swift-log",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-log.git",
-      "state" : {
-        "revision" : "9cb486020ebf03bfa5b5df985387a14a98744537",
-        "version" : "1.6.1"
-      }
-    },
-    {
-      "identity" : "swift-nio",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio.git",
-      "state" : {
-        "revision" : "fc79798d5a150d61361a27ce0c51169b889e23de",
-        "version" : "2.68.0"
-      }
-    },
-    {
-      "identity" : "swift-nio-extras",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio-extras.git",
-      "state" : {
-        "revision" : "05c36b57453d23ea63785d58a7dbc7b70ba1745e",
-        "version" : "1.23.0"
-      }
-    },
-    {
-      "identity" : "swift-nio-http2",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio-http2.git",
-      "state" : {
-        "revision" : "a0224f3d20438635dd59c9fcc593520d80d131d0",
-        "version" : "1.33.0"
-      }
-    },
-    {
-      "identity" : "swift-nio-ssl",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio-ssl.git",
-      "state" : {
-        "revision" : "2b09805797f21c380f7dc9bedaab3157c5508efb",
-        "version" : "2.27.0"
-      }
-    },
-    {
-      "identity" : "swift-nio-transport-services",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio-transport-services.git",
-      "state" : {
-        "revision" : "38ac8221dd20674682148d6451367f89c2652980",
-        "version" : "1.21.0"
-      }
-    },
-    {
-      "identity" : "swift-system",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-system.git",
-      "state" : {
-        "revision" : "6a9e38e7bd22a3b8ba80bddf395623cf68f57807",
-        "version" : "1.3.1"
-      }
-    },
-    {
-      "identity" : "web3.swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/argentlabs/web3.swift",
-      "state" : {
-        "revision" : "1e75f98a5738c470b23bbfffa9314e9f788df76b",
-        "version" : "1.6.1"
-      }
-    },
-    {
-      "identity" : "websocket-kit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/vapor/websocket-kit.git",
-      "state" : {
-        "revision" : "4232d34efa49f633ba61afde365d3896fc7f8740",
-        "version" : "2.15.0"
+        "revision" : "e8d6eba1fef23ae5b359c46b03f7d94be2f41fed",
+        "version" : "3.12.3"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,6 @@ let package = Package(
 	],
 	dependencies: [
 		.package(url: "https://github.com/attaswift/BigInt.git", from: "5.3.0"),
-		.package(url: "https://github.com/argentlabs/web3.swift", from: "1.5.0"),
 		.package(url: "https://github.com/apple/swift-crypto.git", "1.0.0"..<"4.0.0"),
 	],
 	targets: [
@@ -20,7 +19,6 @@ let package = Package(
 			dependencies: [
 				"IDKitCore",
 				.product(name: "BigInt", package: "BigInt"),
-				.product(name: "web3.swift", package: "web3.swift"),
 			],
 			path: "./Sources/IDKit",
 			swiftSettings: [.enableExperimentalFeature("StrictConcurrency")]

--- a/Sources/IDKit/Session.swift
+++ b/Sources/IDKit/Session.swift
@@ -1,4 +1,3 @@
-import web3
 import BigInt
 import IDKitCore
 import Foundation
@@ -19,18 +18,16 @@ public struct Session: Sendable {
 	/// # Errors
 	///
 	/// Throws an error if the request to the bridge fails, or if the response from the bridge is malformed.
-	public init<Signal: ABIType>(
+	public init(
 		_ appID: AppID,
 		action: String,
 		verificationLevel: VerificationLevel = .orb,
 		bridgeURL: BridgeURL = .default,
-		signal: Signal = "",
 		actionDescription: String? = nil
 	) async throws {
-		let payload = try CreateRequestPayload(
+		let payload = CreateRequestPayload(
 			appID: appID,
 			action: action,
-			signal: encodeSignal(signal),
 			actionDescription: actionDescription,
 			verificationLevel: verificationLevel
 		)
@@ -47,10 +44,4 @@ public struct Session: Sendable {
 	public func status() -> AsyncThrowingStream<Status, Error> {
 		return client.status()
 	}
-}
-
-func encodeSignal(_ signal: any ABIType) throws -> String {
-	let bytes = try Data(ABIEncoder.encode(signal, packed: true).bytes).web3.keccak256
-
-	return "0x" + String(BigUInt(bytes) >> 8, radix: 16)
 }

--- a/Sources/IDKit/Types.swift
+++ b/Sources/IDKit/Types.swift
@@ -37,14 +37,12 @@ extension VerificationLevel {
 struct CreateRequestPayload: Codable {
 	let app_id: String
 	let action: String
-	let signal: String
 	let action_description: Optional<String>
 	let verification_level: VerificationLevel
 	let credential_types: [Proof.CredentialType]
 
-	init(appID: AppID, action: String, signal: String, actionDescription: String?, verificationLevel: VerificationLevel) {
+	init(appID: AppID, action: String, actionDescription: String?, verificationLevel: VerificationLevel) {
 		self.action = action
-		self.signal = signal
 		app_id = appID.rawId
 		action_description = actionDescription
 		verification_level = verificationLevel


### PR DESCRIPTION
* Remove `web3` as a dependency as it no longer compiles and relies on an old, unmaintained cryptographic implementation for [keccak256](https://github.com/coruus/keccak-tiny).
* Minor renames of 2 `static` functions in `BridgeClient.swift` to make them more idiomatic.
* Update `Package.resolved`
