### PR TITLE
fix decoding with simulator proof response

### DIFF
--- a/Sources/IDKit/Types.swift
+++ b/Sources/IDKit/Types.swift
@@ -12,7 +12,31 @@ public struct Proof: Codable, Sendable {
 	public let proof: String
 	public let merkle_root: String
 	public let nullifier_hash: String
-	public let credential_type: CredentialType
+	/// [Migrate from `credential_type` to `verification_level`](https://docs.world.org/world-id/reference/world-id-2-migration-guide#migrate-from-credential-types-to-verification-level)
+	@available(*, deprecated, renamed: "verification_level", message: "Renamed to verification_level")
+	public var credential_type: CredentialType { verification_level }
+	public let verification_level: CredentialType
+
+	// Separate coding key definition to avoid compile errors
+	private enum _CodingKeys: CodingKey {
+		case proof
+		case merkle_root
+		case nullifier_hash
+		/// deprecated
+		case credential_type
+		case verification_level
+	}
+	public init(from decoder: any Decoder) throws {
+		let container = try decoder.container(keyedBy: _CodingKeys.self)
+		self.proof = try container.decode(String.self, forKey: .proof)
+		self.merkle_root = try container.decode(String.self, forKey: .merkle_root)
+		self.nullifier_hash = try container.decode(String.self, forKey: .nullifier_hash)
+		if let credentialType = try? container.decodeIfPresent(Proof.CredentialType.self, forKey: .credential_type) {
+			verification_level = credentialType
+		} else {
+			verification_level = try container.decode(Proof.CredentialType.self, forKey: .verification_level)
+		}
+	}
 }
 
 /// The minimum verification level accepted.


### PR DESCRIPTION
The simulator responses include the latest fields regarding the [migration from `credential_types` to `verification_level`](https://docs.world.org/world-id/reference/world-id-2-migration-guide#migrate-from-credential-types-to-verification-level). 

However, physical device responses contain a deprecated response. This issue was only tested with one version of the World App (2.8.9100 on iPhone). Despite this, the changes should be safe with both responses, as they have been tested with both.