### PR TITLE
Add deferredOnboardingURL

### DIFF
--- a/Sources/IDKit/Base64URLEncoding.swift
+++ b/Sources/IDKit/Base64URLEncoding.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+extension Data {
+    public func base64URLEncodedString() -> String {
+        let base64 = self.base64EncodedString()
+        let base64url = base64
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+        return base64url
+    }
+
+    public init?(base64URLEncoded string: String) {
+        var base64 = string
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+
+        let paddingLength = 4 - (base64.count % 4)
+        if paddingLength < 4 {
+            base64 += String(repeating: "=", count: paddingLength)
+        }
+
+        self.init(base64Encoded: base64)
+    }
+}


### PR DESCRIPTION
* Add `deferredOnboardingURL`, which can be used to launch World App Clip if users don't have the app or an account with us yet.

**Note**:
The CI failures are compiler crashes unrelated to the changes in the Pr.