### PR TITLE
Remove trailing parameter comma

### DIFF
--- a/Sources/IDKit/Types.swift
+++ b/Sources/IDKit/Types.swift
@@ -111,7 +111,7 @@ struct CredentialCategoryRequestPayload: Codable {
         action: String,
         signal: String,
         actionDescription: String?,
-        credentialCategories: Set<CredentialCategory>,
+        credentialCategories: Set<CredentialCategory>
     ) {
         self.action = action
         self.signal = signal


### PR DESCRIPTION
* This leads to a compiler failure on older Swift toolchains.
