### PR TITLE
Add myself as codeowner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @m1guelpf @SeanROlszewski @decentralgabe @andy-t-wang
+* @m1guelpf @SeanROlszewski @decentralgabe @andy-t-wang @sideround


### PR DESCRIPTION
## Description
Currently, @SeanROlszewski is the only codeowner that uses Swift on a day-to-day basis. Adding myself to make reviewing and approving PRs easier.