### PR TITLE
Fix Xcode 26 explicit-module-build compilation failure

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,15 +22,25 @@ let package = Package(
             url: "https://github.com/worldcoin/idkit-swift/releases/download/4.0.6-dev.9f6a75d/IDKitFFI.xcframework.zip",
             checksum: "a2eccf872e50c9c80baed65d04853052aa068dc2f1daf2f903c02ceddaaf3c96"
         ),
+        // System-library shim that provides the idkit_coreFFI C module map.
+        // Xcode 26 explicit-module-build mode fails to propagate binary-target
+        // module maps to Swift dependents; this target forces the correct
+        // -fmodule-map-file flag through SPM's official mechanism.
+        .systemLibrary(
+            name: "idkit_coreFFI",
+            path: "Sources/IDKit/Generated"
+        ),
         .target(
             name: "IDKit",
             dependencies: [
-                "idkitFFI"
+                "idkitFFI",
+                "idkit_coreFFI"
             ],
             path: "Sources/IDKit",
             exclude: [
                 "Generated/idkit_coreFFI.h",
-                "Generated/idkit_coreFFI.modulemap"
+                "Generated/idkit_coreFFI.modulemap",
+                "Generated/module.modulemap"
             ]
         )
     ]

--- a/Sources/IDKit/Generated/idkit_coreFFI.modulemap
+++ b/Sources/IDKit/Generated/idkit_coreFFI.modulemap
@@ -2,6 +2,4 @@ module idkit_coreFFI {
     header "idkit_coreFFI.h"
     export *
     use "Darwin"
-    use "_Builtin_stdbool"
-    use "_Builtin_stdint"
 }


### PR DESCRIPTION
Xcode 26 enables explicit module builds for SPM packages by default. Under this mode, C module maps inside binary XCFramework targets are not automatically propagated to Swift dependents, causing a compile error when IDKit tries to import idkit_coreFFI.

- Add a systemLibrary SPM target pointing to Sources/IDKit/Generated/. SPM passes -fmodule-map-file to the Swift compiler via this mechanism, restoring correct module resolution under explicit-module-build mode.
- Add idkit_coreFFI as an explicit dependency of the IDKit target.
- Exclude the C header and module map files from Swift source compilation.
- Remove use "_Builtin_stdbool" and use "_Builtin_stdint" from idkit_coreFFI.modulemap — these private Clang module names are rejected by Xcode 26's explicit module checker.

Fix identified and implemented by Claude (Anthropic).