### PR TITLE
feat: server-driven per-app verify / App Clip URL overrides

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -28,8 +28,6 @@ jobs:
             - os: macos-15
               xcode: "26.0.1"
             - os: macos-26
-              xcode: "16.4"
-            - os: macos-26
               xcode: "26.0.1"
         runs-on: ${{ matrix.os }}
         env:

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -5,9 +5,9 @@ permissions:
 
 on:
     push:
-        branches: [main]
+        branches: [main, "3.x"]
     pull_request:
-        branches: [main]
+        branches: [main, "3.x"]
 
 jobs:
     tests:

--- a/Sources/IDKit/BridgeClient.swift
+++ b/Sources/IDKit/BridgeClient.swift
@@ -52,6 +52,13 @@ func resolveVerificationBaseURL(_ override: String?) -> URL {
 	return defaultVerificationBaseURL
 }
 
+/// Pick the override for `appID` from the bridge's map: an exact `app_id` entry
+/// wins; otherwise the catch-all `"*"` entry (a server-set global default)
+/// applies; otherwise `nil` (the SDK keeps its built-in defaults).
+func selectOverride(_ overrides: [String: AppOverride]?, for appID: String) -> AppOverride? {
+	overrides?[appID] ?? overrides?["*"]
+}
+
 /// An abstraction over the Worldcoin Wallet Bridge.
 public struct BridgeClient<Response: Decodable & Sendable>: Sendable {
 	/// The status of a verification request.
@@ -134,9 +141,9 @@ public struct BridgeClient<Response: Decodable & Sendable>: Sendable {
 
         requestID = response.request_id
 
-        // The bridge returns the whole override map; pick this app's entry (if
-        // any) locally. `appID` is never sent to the bridge.
-        let override = response.app_overrides?[appID]
+        // The bridge returns the whole override map; pick this app's entry (or
+        // the catch-all `"*"`) locally. `appID` is never sent to the bridge.
+        let override = selectOverride(response.app_overrides, for: appID)
         appClipBundleID = override?.app_clip_bundle_id
         verifyURLBase = override?.verify_url
 	}

--- a/Sources/IDKit/BridgeClient.swift
+++ b/Sources/IDKit/BridgeClient.swift
@@ -29,14 +29,15 @@ struct CreateRequestResponse: Codable {
 let defaultVerificationBaseURL = URL(string: "https://world.org/verify")!
 
 /// Whether a server-provided override base is safe to use as a URL: a
-/// well-formed *absolute* http(s) URL with a host. `URL(string:)` is lenient
-/// (e.g. `"not a url"` becomes a relative URL), so we validate explicitly and
-/// fall back to defaults otherwise — untrusted server input must never produce
-/// a broken verification/onboarding URL.
+/// well-formed *absolute* HTTPS URL with a host. HTTP is rejected — a plaintext
+/// verify URL would expose the symmetric `k` query parameter on the network and
+/// wouldn't behave as an iOS universal link, so a misconfigured override must
+/// fall back to the built-in default rather than silently downgrade. `URL(string:)`
+/// is lenient (e.g. `"not a url"` becomes a relative URL), so we validate the
+/// scheme and host explicitly.
 func isUsableOverrideBaseURL(_ string: String) -> Bool {
 	guard let url = URL(string: string),
-	      let scheme = url.scheme?.lowercased(),
-	      scheme == "https" || scheme == "http",
+	      url.scheme?.lowercased() == "https",
 	      url.host?.isEmpty == false
 	else { return false }
 	return true

--- a/Sources/IDKit/BridgeClient.swift
+++ b/Sources/IDKit/BridgeClient.swift
@@ -132,7 +132,7 @@ public struct BridgeClient<Response: Decodable & Sendable>: Sendable {
 	/// # Errors
 	///
 	/// Throws an error if the request to the bridge fails, or if the response from the bridge is malformed.
-    public init<Request: Codable>(sending payload: Request, appID: String, to bridgeURL: BridgeURL = .default, linkType: String = "wld") async throws {
+    public init<Request: Codable>(sending payload: Request, appID: String? = nil, to bridgeURL: BridgeURL = .default, linkType: String = "wld") async throws {
 		self.bridgeURL = bridgeURL
         self.linkType = linkType
         key = SymmetricKey(size: .bits256)
@@ -144,7 +144,9 @@ public struct BridgeClient<Response: Decodable & Sendable>: Sendable {
 
         // The bridge returns the whole override map; pick this app's entry (or
         // the catch-all `"*"`) locally. `appID` is never sent to the bridge.
-        let override = selectOverride(response.app_overrides, for: appID)
+        // Optional so direct BridgeClient callers keep their existing signature;
+        // only Session passes it. No appID → no override (built-in defaults).
+        let override = appID.flatMap { selectOverride(response.app_overrides, for: $0) }
         appClipBundleID = override?.app_clip_bundle_id
         verifyURLBase = override?.verify_url
 	}

--- a/Sources/IDKit/BridgeClient.swift
+++ b/Sources/IDKit/BridgeClient.swift
@@ -4,6 +4,54 @@ import Foundation
 import FoundationNetworking
 #endif
 
+/// A single per-`app_id` URL override entry, as returned by the bridge. Both
+/// fields are independently optional.
+///
+/// - `app_clip_bundle_id`: the App Clip's bundle identifier (the `p` parameter
+///   of an `appclip.apple.com/id` default link). The SDK builds the full link.
+/// - `verify_url`: a verify *base* URL the SDK decorates with query params.
+struct AppOverride: Codable {
+	let app_clip_bundle_id: String?
+	let verify_url: String?
+}
+
+/// The decoded `POST /request` response from the Wallet Bridge.
+struct CreateRequestResponse: Codable {
+	let request_id: UUID
+	/// The full server-driven override map (`app_id → AppOverride`), returned
+	/// verbatim by the bridge. The SDK selects its own `app_id` entry locally.
+	/// Absent when no overrides are configured (or against an older bridge) —
+	/// the SDK then keeps its built-in defaults.
+	let app_overrides: [String: AppOverride]?
+}
+
+/// The default verify base URL when the bridge supplies no override.
+let defaultVerificationBaseURL = URL(string: "https://world.org/verify")!
+
+/// Whether a server-provided override base is safe to use as a URL: a
+/// well-formed *absolute* http(s) URL with a host. `URL(string:)` is lenient
+/// (e.g. `"not a url"` becomes a relative URL), so we validate explicitly and
+/// fall back to defaults otherwise — untrusted server input must never produce
+/// a broken verification/onboarding URL.
+func isUsableOverrideBaseURL(_ string: String) -> Bool {
+	guard let url = URL(string: string),
+	      let scheme = url.scheme?.lowercased(),
+	      scheme == "https" || scheme == "http",
+	      url.host?.isEmpty == false
+	else { return false }
+	return true
+}
+
+/// Resolve the verify *base* URL: prefer the server-driven override when it is
+/// a usable absolute URL, otherwise fall back to the built-in default. A
+/// malformed override must never crash or break verification.
+func resolveVerificationBaseURL(_ override: String?) -> URL {
+	if let override, isUsableOverrideBaseURL(override), let url = URL(string: override) {
+		return url
+	}
+	return defaultVerificationBaseURL
+}
+
 /// An abstraction over the Worldcoin Wallet Bridge.
 public struct BridgeClient<Response: Decodable & Sendable>: Sendable {
 	/// The status of a verification request.
@@ -31,10 +79,6 @@ public struct BridgeClient<Response: Decodable & Sendable>: Sendable {
 		}
 	}
 
-	private struct CreateRequestResponse: Codable {
-		let request_id: UUID
-	}
-
 	private struct BridgeQueryResponse: Codable {
 		let status: String
 		let response: Payload?
@@ -45,6 +89,11 @@ public struct BridgeClient<Response: Decodable & Sendable>: Sendable {
 	let iv: AES.GCM.Nonce
 	let bridgeURL: BridgeURL
     let linkType: String
+	/// Server-driven overrides for this session's `app_id`, or `nil` to use the
+	/// built-in defaults. `appClipBundleID` is the App Clip default-link `p`
+	/// value; `verifyURLBase` is a verify base URL the SDK decorates.
+	let appClipBundleID: String?
+	let verifyURLBase: String?
 
 	/// The URL that the user should be directed to in order to connect their World App to the client.
     @available(*, deprecated, renamed: "connectURL", message: "Prefer connectURL over connect_url")
@@ -64,7 +113,10 @@ public struct BridgeClient<Response: Decodable & Sendable>: Sendable {
             queryParams.append(URLQueryItem(name: "b", value: bridgeURL.rawURL.absoluteString))
         }
 
-        return URL(string: "https://worldcoin.org/verify")!.appending(queryItems: queryParams)
+        // Prefer the server-driven verify base when present, but never trust it
+        // blindly: a malformed override falls back to the built-in default
+        // rather than crashing.
+        return resolveVerificationBaseURL(verifyURLBase).appending(queryItems: queryParams)
     }
 
 	/// Create a new session with the Wallet Bridge.
@@ -72,7 +124,7 @@ public struct BridgeClient<Response: Decodable & Sendable>: Sendable {
 	/// # Errors
 	///
 	/// Throws an error if the request to the bridge fails, or if the response from the bridge is malformed.
-    public init<Request: Codable>(sending payload: Request, to bridgeURL: BridgeURL = .default, linkType: String = "wld") async throws {
+    public init<Request: Codable>(sending payload: Request, appID: String, to bridgeURL: BridgeURL = .default, linkType: String = "wld") async throws {
 		self.bridgeURL = bridgeURL
         self.linkType = linkType
         key = SymmetricKey(size: .bits256)
@@ -81,6 +133,12 @@ public struct BridgeClient<Response: Decodable & Sendable>: Sendable {
         let response = try await Self.create_request(payload.encrypt(with: key, nonce: iv), bridgeURL: bridgeURL)
 
         requestID = response.request_id
+
+        // The bridge returns the whole override map; pick this app's entry (if
+        // any) locally. `appID` is never sent to the bridge.
+        let override = response.app_overrides?[appID]
+        appClipBundleID = override?.app_clip_bundle_id
+        verifyURLBase = override?.verify_url
 	}
 
 	/// Retrieve the status of the verification request.

--- a/Sources/IDKit/Session.swift
+++ b/Sources/IDKit/Session.swift
@@ -19,6 +19,29 @@ public enum SessionError: Error, CustomDebugStringConvertible {
     }
 }
 
+/// The default App Clip bundle id (the `p` value of the App Clip default link)
+/// when the bridge supplies no override.
+let defaultAppClipBundleID = "org.worldcoin.insight.Clip"
+
+/// Whether a server-provided App Clip bundle id is safe to drop into the `p`
+/// parameter of an `appclip.apple.com/id` default link: non-empty and limited
+/// to the URL-safe characters bundle identifiers actually use (ASCII
+/// alphanumerics plus `.` and `-`). Anything else falls back to the default.
+func isValidAppClipBundleID(_ id: String) -> Bool {
+    !id.isEmpty && id.allSatisfy { $0.isASCII && ($0.isLetter || $0.isNumber || $0 == "." || $0 == "-") }
+}
+
+/// Build the deferred-onboarding App Clip default link from a bundle id and the
+/// per-request `experience`. Only the bundle id (`p`) varies per app — the host,
+/// path, and `experience` mechanism are fixed by the SDK — so the bridge sends
+/// just the bundle id and the SDK assembles a well-formed link deterministically
+/// (no URL parsing / separator guessing). A missing or malformed bundle id falls
+/// back to the built-in default.
+func buildAppClipURL(bundleID override: String?, experience: String) -> String {
+    let bundleID = override.flatMap { isValidAppClipBundleID($0) ? $0 : nil } ?? defaultAppClipBundleID
+    return "https://appclip.apple.com/id?p=\(bundleID)&experience=\(experience)"
+}
+
 /// A World ID session with the Wallet Bridge.
 public struct Session<Response: Decodable & Sendable>: Sendable {
 	public typealias Status = BridgeClient<Response>.Status
@@ -54,7 +77,7 @@ public struct Session<Response: Decodable & Sendable>: Sendable {
             }
 
             let experience = data.base64URLEncodedString()
-            let urlString = "https://appclip.apple.com/id?p=org.worldcoin.insight.Clip&experience=\(experience)"
+            let urlString = buildAppClipURL(bundleID: client.appClipBundleID, experience: experience)
 
             guard let deferredOnboardingURL = URL(string: urlString) else {
                 throw SessionError.deferredOnboardingURLInvalid(urlString)
@@ -97,7 +120,7 @@ public extension Session where Response == Proof {
             verificationLevel: verificationLevel
         )
 
-        client = try await BridgeClient(sending: payload, to: bridgeURL, linkType: "wld")
+        client = try await BridgeClient(sending: payload, appID: appID.rawId, to: bridgeURL, linkType: "wld")
     }
 }
 
@@ -136,7 +159,7 @@ public extension Session where Response == CredentialCategoryProofResponse {
             credentialCategories: credentialCategories
         )
 
-        client = try await BridgeClient(sending: payload, to: bridgeURL, linkType: "cred")
+        client = try await BridgeClient(sending: payload, appID: appID.rawId, to: bridgeURL, linkType: "cred")
     }
 }
 

--- a/Tests/IDKitTests/Tests.swift
+++ b/Tests/IDKitTests/Tests.swift
@@ -153,6 +153,26 @@ import Testing
 	#expect(decoded.app_overrides?["app_absent"] == nil)
 }
 
+@Test func testSelectOverridePrefersExactMatchOverWildcard() {
+	let map = [
+		"app_mine": AppOverride(app_clip_bundle_id: "org.mine.Clip", verify_url: nil),
+		"*": AppOverride(app_clip_bundle_id: "org.fallback.Clip", verify_url: nil),
+	]
+	#expect(selectOverride(map, for: "app_mine")?.app_clip_bundle_id == "org.mine.Clip")
+}
+
+@Test func testSelectOverrideFallsBackToWildcard() {
+	// No exact entry → the catch-all "*" applies.
+	let map = ["*": AppOverride(app_clip_bundle_id: "org.fallback.Clip", verify_url: nil)]
+	#expect(selectOverride(map, for: "app_unknown")?.app_clip_bundle_id == "org.fallback.Clip")
+}
+
+@Test func testSelectOverrideNoneWhenNoMatchAndNoWildcard() {
+	let map = ["app_other": AppOverride(app_clip_bundle_id: "org.other.Clip", verify_url: nil)]
+	#expect(selectOverride(map, for: "app_unknown") == nil)
+	#expect(selectOverride(nil, for: "app_unknown") == nil)
+}
+
 @Test func testCreateRequestResponseToleratesMissingOverrideMap() throws {
 	// An older bridge (or one with no overrides configured) returns only
 	// request_id — app_overrides must decode to nil, not throw.

--- a/Tests/IDKitTests/Tests.swift
+++ b/Tests/IDKitTests/Tests.swift
@@ -115,6 +115,12 @@ import Testing
 	#expect(resolveVerificationBaseURL("not a url") == URL(string: "https://world.org/verify")!)
 }
 
+@Test func testVerifyBaseRejectsPlaintextHTTP() {
+	// An http:// override would leak the `k` param in cleartext and wouldn't act
+	// as a universal link — it must be rejected and fall back to the HTTPS default.
+	#expect(resolveVerificationBaseURL("http://verify.example.com/v") == URL(string: "https://world.org/verify")!)
+}
+
 @Test func testAppClipURLDefaultsToWorldcoinBundle() {
 	let url = buildAppClipURL(bundleID: nil, experience: "EXP")
 	#expect(url == "https://appclip.apple.com/id?p=org.worldcoin.insight.Clip&experience=EXP")

--- a/Tests/IDKitTests/Tests.swift
+++ b/Tests/IDKitTests/Tests.swift
@@ -1,4 +1,5 @@
 @testable import IDKit
+import Foundation
 import Testing
 
 @Test(.disabled("Run this manually to test the library!")) func testFlow() async throws {
@@ -85,13 +86,80 @@ import Testing
 @Test func testEncodeSignalFormat() throws {
 	// All outputs should have the format: 0x + 64 hex characters
 	let testCases = ["test", "hello", "123", ""]
-	
+
 	for testCase in testCases {
 		let result = try encodeSignal(testCase)
 		#expect(result.hasPrefix("0x"))
 		#expect(result.count == 66)
-		
+
 		let hexPart = String(result.dropFirst(2))
 		#expect(hexPart.allSatisfy { $0.isHexDigit })
 	}
+}
+
+// MARK: - Server-driven URL override Tests
+
+@Test func testVerifyBaseDefaultsToWorldOrg() {
+	// No override → the built-in default (note: world.org, not worldcoin.org).
+	#expect(resolveVerificationBaseURL(nil) == URL(string: "https://world.org/verify")!)
+}
+
+@Test func testVerifyBaseHonorsOverride() {
+	let override = "https://verify.example.com/v"
+	#expect(resolveVerificationBaseURL(override) == URL(string: override)!)
+}
+
+@Test func testVerifyBaseFallsBackOnMalformedOverride() {
+	// A malformed override must never crash or break verification — fall back.
+	#expect(resolveVerificationBaseURL("") == URL(string: "https://world.org/verify")!)
+	#expect(resolveVerificationBaseURL("not a url") == URL(string: "https://world.org/verify")!)
+}
+
+@Test func testAppClipURLDefaultsToWorldcoinBundle() {
+	let url = buildAppClipURL(bundleID: nil, experience: "EXP")
+	#expect(url == "https://appclip.apple.com/id?p=org.worldcoin.insight.Clip&experience=EXP")
+}
+
+@Test func testAppClipURLHonorsBundleIDOverride() {
+	let url = buildAppClipURL(bundleID: "org.example.app.Clip", experience: "EXP")
+	#expect(url == "https://appclip.apple.com/id?p=org.example.app.Clip&experience=EXP")
+}
+
+@Test func testAppClipURLFallsBackOnMalformedBundleID() {
+	// A bundle id with URL-unsafe characters (would break the `p` param) must
+	// fall back to the default rather than producing a broken onboarding URL.
+	#expect(buildAppClipURL(bundleID: "", experience: "EXP")
+		== "https://appclip.apple.com/id?p=org.worldcoin.insight.Clip&experience=EXP")
+	#expect(buildAppClipURL(bundleID: "org.example/../evil&x=1", experience: "EXP")
+		== "https://appclip.apple.com/id?p=org.worldcoin.insight.Clip&experience=EXP")
+}
+
+@Test func testCreateRequestResponseDecodesOverrideMapAndSelectsAppEntry() throws {
+	// The bridge returns the whole map; the SDK picks its own app_id entry.
+	let json = """
+	{"request_id":"00000000-0000-0000-0000-000000000000","app_overrides":{
+		"app_mine":{"app_clip_bundle_id":"org.example.Clip","verify_url":"https://world.org/verify"},
+		"app_other":{"app_clip_bundle_id":"org.other.Clip"}
+	}}
+	""".data(using: .utf8)!
+
+	let decoded = try JSONDecoder().decode(CreateRequestResponse.self, from: json)
+
+	let mine = decoded.app_overrides?["app_mine"]
+	#expect(mine?.app_clip_bundle_id == "org.example.Clip")
+	#expect(mine?.verify_url == "https://world.org/verify")
+
+	// An app not in the map → no override (SDK falls back to defaults).
+	#expect(decoded.app_overrides?["app_absent"] == nil)
+}
+
+@Test func testCreateRequestResponseToleratesMissingOverrideMap() throws {
+	// An older bridge (or one with no overrides configured) returns only
+	// request_id — app_overrides must decode to nil, not throw.
+	let json = """
+	{"request_id":"00000000-0000-0000-0000-000000000000"}
+	""".data(using: .utf8)!
+
+	let decoded = try JSONDecoder().decode(CreateRequestResponse.self, from: json)
+	#expect(decoded.app_overrides == nil)
 }


### PR DESCRIPTION
## What

Adds server-driven, per-`app_id` overrides for the SDK's **verify base URL** and **App Clip bundle id**, consumed from the Wallet Bridge's `app_overrides` map on `POST /request` — so an app's verify/App-Clip routing can change server-side without a new SDK release. Also renames the default verify base `worldcoin.org/verify → world.org/verify`.

Targets **`3.x`** (the native-Swift release line) rather than `main` (which is now the 4.x Rust relay). Companion to wallet-bridge [#98](https://github.com/worldcoin/wallet-bridge/pull/98) and world-id-deploy [#532](https://github.com/worldcoin/world-id-deploy/pull/532).

## How

- `BridgeClient` decodes the whole `app_overrides` map and selects this session's entry **locally** by `appID` — `appID` is **not** sent to the bridge; the request body is unchanged. Selection precedence: **exact `app_id` → `"*"` catch-all → built-in default**.
- `verificationURL` uses the override's `verify_url` base (else `https://world.org/verify`); `Session.deferredOnboardingURL` builds the App Clip default link from the override's `app_clip_bundle_id` (the `p` param of an `appclip.apple.com/id` link) — only the bundle id varies, the SDK assembles the rest, so there's no URL re-parsing.
- **Fail-safe:** a missing entry/field or a malformed value falls back to the built-in defaults (`org.worldcoin.insight.Clip`, `world.org`), guarded by `isUsableOverrideBaseURL` / `isValidAppClipBundleID` (`URL(string:)` is lenient, so overrides must be absolute http(s)+host / a valid bundle-id charset).

## Tests

`swift test` — 26 tests: override selection (exact wins over `"*"`, `"*"` fallback, none), decode tolerance (absent map → nil), and the verify/App-Clip fallback paths.

Verified end-to-end against the deployed **staging** bridge: `app_18c325…` → `org.world.staging.id.Clip` (exact), `app_75c2486…` → `org.world.staging.id.Clip` via the `"*"` wildcard.

## Notes

- Base is `3.x` (created off `f25cfb2`, the last native commit) so the diff is exactly this feature. Release will be tagged off `3.x`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)