### PR TITLE
fix: opt into app_overrides via supports_app_overrides flag

### DIFF
--- a/Sources/IDKit/BridgeClient.swift
+++ b/Sources/IDKit/BridgeClient.swift
@@ -15,12 +15,23 @@ struct AppOverride: Codable {
 	let verify_url: String?
 }
 
+/// The body sent to `POST /request`: the opaque encrypted `iv`/`payload` plus
+/// the capability flag. The bridge only returns `app_overrides` when
+/// `supports_app_overrides` is `true`; this SDK can parse that field, so it
+/// always opts in. (The flag exists because adding the field unconditionally
+/// broke shipped strict-decoder clients — see wallet-bridge #99.)
+struct CreateRequestBody: Encodable {
+	let iv: String
+	let payload: String
+	let supports_app_overrides: Bool
+}
+
 /// The decoded `POST /request` response from the Wallet Bridge.
 struct CreateRequestResponse: Codable {
 	let request_id: UUID
 	/// The full server-driven override map (`app_id → AppOverride`), returned
 	/// verbatim by the bridge. The SDK selects its own `app_id` entry locally.
-	/// Absent when no overrides are configured (or against an older bridge) —
+	/// Absent when no overrides are configured (or the client didn't opt in) —
 	/// the SDK then keeps its built-in defaults.
 	let app_overrides: [String: AppOverride]?
 }
@@ -212,8 +223,11 @@ public struct BridgeClient<Response: Decodable & Sendable>: Sendable {
 	private static func create_request(_ data: Payload, bridgeURL: BridgeURL) async throws -> CreateRequestResponse {
 		var request = URLRequest(url: bridgeURL.rawURL.appendingPathComponent("request"))
 
+		// Opt into the gated `app_overrides` response field (wallet-bridge #99).
+		let body = CreateRequestBody(iv: data.iv, payload: data.payload, supports_app_overrides: true)
+
 		request.httpMethod = "POST"
-		request.httpBody = try JSONEncoder().encode(data)
+		request.httpBody = try JSONEncoder().encode(body)
 
 		request.setValue("idkit-swift", forHTTPHeaderField: "User-Agent")
 		request.setValue("application/json", forHTTPHeaderField: "Content-Type")

--- a/Tests/IDKitTests/Tests.swift
+++ b/Tests/IDKitTests/Tests.swift
@@ -179,6 +179,16 @@ import Testing
 	#expect(selectOverride(nil, for: "app_unknown") == nil)
 }
 
+@Test func testCreateRequestBodyOptsIntoAppOverrides() throws {
+	// The SDK must send supports_app_overrides=true or the bridge withholds the
+	// app_overrides map (wallet-bridge #99 gated it behind this opt-in flag).
+	let body = CreateRequestBody(iv: "IV", payload: "PAYLOAD", supports_app_overrides: true)
+	let object = try JSONSerialization.jsonObject(with: JSONEncoder().encode(body)) as! [String: Any]
+	#expect(object["supports_app_overrides"] as? Bool == true)
+	#expect(object["iv"] as? String == "IV")
+	#expect(object["payload"] as? String == "PAYLOAD")
+}
+
 @Test func testCreateRequestResponseToleratesMissingOverrideMap() throws {
 	// An older bridge (or one with no overrides configured) returns only
 	// request_id — app_overrides must decode to nil, not throw.


### PR DESCRIPTION
This PR adopts https://github.com/worldcoin/wallet-bridge/pull/99 changes and opts in the `support_app_overrides` flag to receive the app overrides payload